### PR TITLE
Fixed issue seen with lib_spi CMakeLists

### DIFF
--- a/test/hil/lib_spi/spi_master_sync_multi_device/CMakeLists.txt
+++ b/test/hil/lib_spi/spi_master_sync_multi_device/CMakeLists.txt
@@ -49,7 +49,7 @@ foreach(load ${FULL_LOAD})
         foreach(mosi ${MOSI_ENABLED})
             foreach(mode ${SPI_MODE})
                 foreach(div ${DIVS})
-                    if(${MISO_ENABLED} OR ${MOSI_ENABLED})
+                    if(${miso} OR ${mosi})
                         set(TARGET_NAME_NO_EXT "${APP_NAME}_${load}_${miso}_${mosi}_${div}_${mode}")
                         set(TARGET_NAME "${TARGET_NAME_NO_EXT}.xe")
 

--- a/test/hil/lib_spi/spi_master_sync_rx_tx/CMakeLists.txt
+++ b/test/hil/lib_spi/spi_master_sync_rx_tx/CMakeLists.txt
@@ -49,7 +49,7 @@ foreach(load ${FULL_LOAD})
         foreach(mosi ${MOSI_ENABLED})
             foreach(mode ${SPI_MODE})
                 foreach(div ${DIVS})
-                    if(${MISO_ENABLED} OR ${MOSI_ENABLED})
+                    if(${miso} OR ${mosi})
                         set(TARGET_NAME_NO_EXT "${APP_NAME}_${load}_${miso}_${mosi}_${div}_${mode}")
                         set(TARGET_NAME "${TARGET_NAME_NO_EXT}.xe")
 


### PR DESCRIPTION
When trying to run CMake on lib_spi, the following error is observed:

CMake Error at lib_spi/spi_master_sync_multi_device/CMakeLists.txt:52 (if):

    if given arguments:

    "0" "1" "OR" "0" "1"

    Unknown arguments specified

This fix resolves this by correcting a small error in the CMakeLists for spi_master_sync_multi_device and spi_master_sync_rx_tx